### PR TITLE
add Example dir to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -25,3 +25,5 @@ DerivedData
 
 # Pods
 Pods
+
+Example/


### PR DESCRIPTION
ignore unneccessary Example dir to reduce bundle size